### PR TITLE
fix tagline height on mobile

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -785,6 +785,7 @@ input[type="text"]:focus, input[type="email"]:focus, input[type="password"]:focu
 
 .landing .tagline {
   padding: 30px 0;
+  height: 4em;
 }
 /* line 16, ../../../sass/layout/_home.sass */
 


### PR DESCRIPTION
Fix on mobile mode that the button will move because of the tagline height.

![Imgur](http://i.imgur.com/4a1ubQb.png)

![Imgur](http://i.imgur.com/SN3RPLN.png)
